### PR TITLE
Added cursor moveaway after click

### DIFF
--- a/Wabbajack Automagic/MainWindow.xaml.cs
+++ b/Wabbajack Automagic/MainWindow.xaml.cs
@@ -77,6 +77,7 @@ namespace Wabbajack_Automagic
                 outputToConsole("Found button at: (" + currentPoint.Value.X + "," + currentPoint.Value.Y + ")");
                 clickMouse(currentPoint.Value.X + (slowButton.Width / 2), currentPoint.Value.Y + (slowButton.Height / 2));
                 wait(5000);
+                SetCursorPos(0, 0);
             }
             else
             {


### PR DESCRIPTION
Hello! Firstly, thank you for the awesome tool! It saves a lot of time!!!

However, I was frequently running into a situation where after a successful click, mouse cursor stays the same position, so it overlays the button and makes it impossible to recognize it next time without moving it away. So what I do is to set cursor position to (0,0) right before other cycle iteration of the timer begins. This fix is not cricual at all, but saves some seconds (or even minites) and I'm sure you'll find better coding solution if you'd like. Nevertheless, I just made one-line hotfix to be able to open a PR to show a possible solution instead of an ordinary Issue.

Thank you and good luck!